### PR TITLE
Fix build with recent fmt library

### DIFF
--- a/src/KDGpu/adapter_swapchain_properties.h
+++ b/src/KDGpu/adapter_swapchain_properties.h
@@ -13,6 +13,7 @@
 #include <KDGpu/gpu_core.h>
 #include <KDGpu/utils/logging.h>
 
+#include <fmt/ranges.h>
 #include <vector>
 
 namespace KDGpu {

--- a/src/KDGpu/vulkan/vulkan_formatters.h
+++ b/src/KDGpu/vulkan/vulkan_formatters.h
@@ -39,7 +39,7 @@ inline std::string getResultAsString(VkResult vulkan_result)
 template<>
 struct KDGPU_EXPORT fmt::formatter<VkResult> : fmt::formatter<std::string> {
     template<typename FormatContext>
-    auto format(VkResult const &result, FormatContext &ctx)
+    auto format(VkResult const &result, FormatContext &ctx) const
     {
         return fmt::formatter<std::string>::format(getResultAsString(result), ctx);
     }

--- a/src/KDXr/utils/formatters.h
+++ b/src/KDXr/utils/formatters.h
@@ -52,7 +52,7 @@ inline std::string getVersionAsString(uint64_t version)
 template<>
 struct KDXR_EXPORT fmt::formatter<KDXr::SessionState> : fmt::formatter<std::string> {
     template<typename FormatContext>
-    auto format(KDXr::SessionState const &state, FormatContext &ctx)
+    auto format(KDXr::SessionState const &state, FormatContext &ctx) const
     {
         return fmt::formatter<std::string>::format(getSessionStateAsString(state), ctx);
     }


### PR DESCRIPTION
One missing include for fmt::join and fixes errors like:

```
    note: candidate function template not viable: 'this' argument has type 'const fmt::formatter<KDXr::SessionState>', but method is not marked const
       55 |     auto format(KDXr::SessionState const &state, FormatContext &ctx)
```