### PR TITLE
Fix crash, when a TextureView referenced by a framebuffer is deleted

### DIFF
--- a/src/KDGpu/vulkan/vulkan_texture_view.h
+++ b/src/KDGpu/vulkan/vulkan_texture_view.h
@@ -15,6 +15,8 @@
 
 #include <vulkan/vulkan.h>
 
+#include "vulkan_framebuffer.h"
+
 namespace KDGpu {
 
 struct Texture_t;
@@ -33,6 +35,7 @@ struct KDGPU_EXPORT VulkanTextureView {
     VkImageView imageView{ VK_NULL_HANDLE };
     Handle<Texture_t> textureHandle;
     Handle<Device_t> deviceHandle;
+    std::vector<VulkanFramebufferKey> associatedFrameBuffers;
 };
 
 } // namespace KDGpu


### PR DESCRIPTION
In VulkanResourceManager::createRenderPassCommandRecorder Vulkan framebuffers are created on demand. Then if a TextureView associated with an exisiting Vulkan framebuffer is deleted it the application will crash.
Keep track what framebuffers are associated with the TextureView, and when it's deleted also cleanup the device framebuffers.